### PR TITLE
Synonym error message improvements ebi-ait/checklist#77 ebi-ait/check…

### DIFF
--- a/src/main/resources/templates/biosamples_template.vm
+++ b/src/main/resources/templates/biosamples_template.vm
@@ -42,6 +42,7 @@
         "allOf": [
         #foreach ($synonyms in $required)
           {
+            "errorMessage": "Just one of the following properties must be specified: #foreach($synonym in $synonyms)'$synonym'#if($foreach.hasNext), #end#end",
             "oneOf": [
             #foreach ($synonym in $synonyms)
               {


### PR DESCRIPTION
ebi-ait/checklist#77 ebi-ait/checklist#67

Improve synonym error messages by adding `errorMessage` to schema template inside `allof`. This should be used by `ajv-errors`.  
```
"errorMessage": "Just one of the following properties must be specified: 'collection_date', 'collection date', 'Event Date/Time'"
```