### PR TITLE
change default accession prefix to ERC

### DIFF
--- a/src/main/java/uk/ac/ebi/biosamples/jsonschemastore/config/SchemaStoreProperties.java
+++ b/src/main/java/uk/ac/ebi/biosamples/jsonschemastore/config/SchemaStoreProperties.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class SchemaStoreProperties {
 
-    @Value("${schemastore.authority:BIOSAMPLES}")
+    @Value("${schemastore.authority:ENA}")
     private String defaultAuthority;
 
     @Value("${schemastore.validator.url:http://localhost:3020/validate}")

--- a/src/main/java/uk/ac/ebi/biosamples/jsonschemastore/service/AccessioningService.java
+++ b/src/main/java/uk/ac/ebi/biosamples/jsonschemastore/service/AccessioningService.java
@@ -35,7 +35,7 @@ public class AccessioningService {
     private String createNewAccession(String schemaId, int retries) {
         String latestAccession = schemaRepository.findFirstByAuthorityOrderByAccessionDesc(properties.getDefaultAuthority())
                 .map(MongoJsonSchema::getAccession)
-                .orElse("BSDC00000");
+                .orElse("ERC00000");
         String accession = incrementAccession(latestAccession);
         MongoJsonSchema mongoJsonSchema = new MongoJsonSchema();
         mongoJsonSchema.setAccession(accession);
@@ -60,7 +60,7 @@ public class AccessioningService {
     }
 
     private String incrementAccession(String accession) {
-        int accessionNumber = Integer.parseInt(accession.split("BSDC")[1]);
-        return "BSDC" + String.format("%05d", ++accessionNumber);
+        int accessionNumber = Integer.parseInt(accession.split("ERC")[1]);
+        return "ERC" + String.format("%06d", ++accessionNumber);
     }
 }

--- a/src/test/java/uk/ac/ebi/biosamples/jsonschemastore/service/AccessioningServiceTest.java
+++ b/src/test/java/uk/ac/ebi/biosamples/jsonschemastore/service/AccessioningServiceTest.java
@@ -43,7 +43,7 @@ class AccessioningServiceTest {
     public void setup() {
         when(schemaRepository.findFirstByOrderByAccessionDesc()).thenReturn(Optional.of(getSchema()));
         when(schemaRepository.insert(any(MongoJsonSchema.class))).thenReturn(getSchema());
-        when(properties.getDefaultAuthority()).thenReturn("BIOSAMPLES");
+        when(properties.getDefaultAuthority()).thenReturn("ENA");
     }
 
     @Test


### PR DESCRIPTION
- New checklists should be created as Authority=ENA
- Create accession with prefix ERC
- Manually created BioSamples checklists still has prefix of BSDC

At the moment, prefix is hardcoded. We will leave this as it is and later think of a strategy to add prefix to configuration. 


ebi-ait/checklist#177