### PR TITLE
bug/fix empty enum arrays in JSON Schema

### DIFF
--- a/src/main/resources/templates/biosamples_template.vm
+++ b/src/main/resources/templates/biosamples_template.vm
@@ -25,7 +25,7 @@
             "properties": {
               "text": $property.type()
 
-              #if ($property.units())
+              #if ($property.units() && !$property.units().isEmpty())
               ,
               "unit": {
                 "enum": [
@@ -36,7 +36,7 @@
               }
               #end
             },
-            "required":["text"#if ($property.units()), "unit"#end]
+            "required":["text"#if ($property.units() && !$property.units().isEmpty()), "unit"#end]
           }
         }#if( $foreach.hasNext ),#end
       #end


### PR DESCRIPTION
JSON Schema generation: do not generate units field if units is empty